### PR TITLE
Revert "Bump lodash from 4.2.1 to 4.17.13"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,7 +476,7 @@
         "json-fallback": "0.0.1",
         "jsonp": "~0.0.4",
         "packageify": "^0.2.0",
-        "qs": "git://github.com/jfromaniello/node-querystring.git#5d96513991635e3e22d7aa54a8584d6ce97cace8",
+        "qs": "qs@git://github.com/jfromaniello/node-querystring.git#5d96513991635e3e22d7aa54a8584d6ce97cace8",
         "reqwest": "^1.1.4",
         "trim": "~0.0.1",
         "winchan": "^0.1.1",
@@ -6937,9 +6937,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.2.1.tgz",
+      "integrity": "sha1-Fx/c+7ww1onFRM0YwFKfVt5sGqk="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "footable": "~2.0.3",
     "icheck": "1.0.2",
     "jquery": "~2.1.1",
-    "lodash": "~4.17.13",
+    "lodash": "~4.2.0",
     "metismenu": "~2.0.2",
     "moment": "~2.11.2",
     "moment-timezone": "~0.5.0",


### PR DESCRIPTION
Reverts topcoder-platform/admin-app#125

It causes issues like this:

![image](https://user-images.githubusercontent.com/146016/79245047-3fd41a00-7e80-11ea-97f2-8cbf2e687372.png)

Looks like in the newer version of the lodash `_` is no longer global value.
